### PR TITLE
Refactor for using CUB segmented radix sort

### DIFF
--- a/build_and_run.sh
+++ b/build_and_run.sh
@@ -14,8 +14,7 @@ cd build
 
 ln -s ../lunus_proxy.h .
 
-#export CFLAGS="-g -O3 -fopenmp -fPIC -DUSE_OPENMP -DLUNUS_TEAMS=64 -DLUNUS_THREADS=8 -DDEBUG -I. -L."
-export CFLAGS="-g -O3 -fopenmp -fPIC -DUSE_OPENMP -DUSE_OFFLOAD -DLUNUS_TEAMS=64 -DLUNUS_THREADS=32 -DDEBUG -I. -L."
+export CFLAGS="-g -O3 -fopenmp -fPIC -DUSE_OPENMP -DUSE_OFFLOAD -DLUNUS_NUM_JBLOCKS=1 -DLUNUS_NUM_IBLOCKS=1 -DDEBUG -I. -L."
 
 ${CC} $CFLAGS -c ../llunus_proxy.c
 


### PR DESCRIPTION
Separate the code within the outer loop into three sections:

o Create an array of window arrays, stacked end-to-end
  - To make the windows uniform sized, include masked pixel
    values in the arrays, defined using maximum ulong value
o Sort each of the window arrays via a quickSortList call
o Analyze the sorted windows to determine the output pixel values

Next step should be to call cub::DeviceSegmentedRadixSort
to sort the window arrays as keys